### PR TITLE
add mandrill as provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 > Preprocessing and Sending HTML Emails in Node.js
 
+## Goals
+
+1. Send HTML Emails
+2. Use preprocessors like [Jade](http://jade-lang.com/) and [Sass](http://sass-lang.com/) to write them
+3. Only care about the template and its data at time of sending
 
 ## Getting Started
 This plugin requires Grunt `~0.4.2`
@@ -61,7 +66,7 @@ Default value: `{ url: 'file://' + process.cwd() + '/' }`
 
 Same as [Juice options](https://github.com/LearnBoost/juice#juicefilepath-options-callback)
 
-_Pro Tip: End your `url` with a trailing slash_
+_**Important**: End your `url` with a trailing slash_
 
 ### Usage Example
 
@@ -86,22 +91,111 @@ grunt.initConfig({
 
 ## Using in your application
 
-See the [examples](https://github.com/maxbeatty/jamoose/tree/master/examples)
+See the [examples](https://github.com/maxbeatty/jamoose/tree/master/examples) for detailed, working code.
 
-### Sending Email
+1. Create your email template using Jade. Use Jade variables for anything you want replaced at build time (think cross-app vars like domains and dates). Use Mustache variables for anything you want inserted at send time (think user-specific details like name or address)
 
-Currently, jamoose uses [SendGrid](https://github.com/sendgrid/sendgrid-nodejs) to send emails underneath the covers. These environment variables must be set:
+```jade
+//- welcome.jade
+html
+  body
+    table
+      tr
+        td
+          h1 Welcome {{name}}
 
-- `SENDGRID_USER`
-- `SENDGRID_KEY`
+      tr
+        td
+          a(href=domain + '/privacy') Privacy Policy
+```
+
+```sass
+h1
+  font-size: 30px
+  color: #333
+```
+
+2. Build your templates with Grunt
+
+```bash
+$ grunt sass jamoose
+```
+
+You now will have an HTML file with Mustache variables still in tact.
+
+```html
+<html>
+  <body>
+    <table>
+      <tr>
+        <td>
+          <h1>Welcome {{name}}</h1>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="http://your.domain.from.grunt/privacy">Privacy Policy</a>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>
+```
+
+3. Send an email in your app
+
+```js
+var jamoose = require('jamoose'),
+    mailer = new jamoose({
+      tplPath: 'path/to/templates/from/grunt/',
+      fromEmail: 'sender@edc.ba'
+    });
+
+mailer.send(
+  'test@abc.de', // to
+  'Welcome!', // subject
+  'welcome', // template
+  { // data
+    name: 'John Smith'
+  },
+  function(err) { // callback
+    if (err) { console.log(err); }
+  }
+);
+```
+
+"Welcome John Smith" will be sent to "test@abc.de" from "sender@edc.ba" with the subject "Welcome!"
+
+### Email Providers
+
+Currently supporting:
+
+- [SendGrid](http://sendgrid.com/)
+- [Mandrill](https://mandrillapp.com/)
 
 Please submit a pull request to add more service providers.
+
+Set the environment variables for the provider of your choice and it will be used automatically.
+
+#### SendGrid
+
+[SendGrid's node library](https://github.com/sendgrid/sendgrid-nodejs) is used under the hood. Required environment variables:
+
+- `SENDGRID_USER` - API user (usually email address)
+- `SENDGRID_KEY` - API key (usually your password)
+
+#### Mandrill
+
+[Mandrill's node library](https://bitbucket.org/mailchimp/mandrill-api-node) is used under the hood. Required environment variable:
+
+- `MANDRILL` - API key (create one from [your settings page](https://mandrillapp.com/settings/index))
 
 ## Contributing
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint and test your code using [Grunt](http://gruntjs.com/).
 
 ## Release History
-_(Nothing yet)_
+
+v1.0.0 - Add Mandrill support
 
 ## License
 Copyright (c) 2014 Max Beatty

--- a/examples/zurb-ink/mailers/user.js
+++ b/examples/zurb-ink/mailers/user.js
@@ -1,9 +1,10 @@
-var Mailer = require('../../../lib/jamoose'),
-    userMailer = new Mailer({
-      tplPath: '/../views/mailers/user/'
+var jamoose = require('../../../lib/jamoose'),
+    mailer = new jamoose({
+      tplPath: '/../views/mailers/user/',
+      fromEmail: 'sender@edc.ba'
     });
 
-userMailer.send(
+mailer.send(
   'test@abc.de', // to
   'Welcome!', // subject
   'welcome', // template

--- a/examples/zurb-ink/views/mailers/zurb_ink_basic_template.jade
+++ b/examples/zurb-ink/views/mailers/zurb_ink_basic_template.jade
@@ -37,6 +37,6 @@ html(xmlns='http://www.w3.org/1999/xhtml')
                           tr
                             td(align='center')
                               center
-                                a(href='#') Terms
+                                a(href=your_url + '/terms') Terms
                                 &nbsp;&middot;&nbsp;
-                                a(href='https://www.isocket.com/privacy') Privacy
+                                a(href=your_url + '/privacy') Privacy

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jamoose",
   "description": "Preprocessing and Sending HTML Emails in Node.js",
-  "version": "0.3.0-0",
+  "version": "1.0.0",
   "homepage": "https://github.com/maxbeatty/jamoose",
   "author": {
     "name": "Max Beatty",
@@ -37,7 +37,8 @@
     "jade": "~1.0.2",
     "juice": "~0.4.0",
     "hogan.js": "~2.0.0",
-    "sendgrid": "~1.0.0-rc.1.0"
+    "sendgrid": "~1.0.0-rc.1.0",
+    "mandrill-api": "~1.0.39"
   },
   "devDependencies": {
     "coffee-script": "~1.6.3",

--- a/test/grunt_jamoose_test.coffee
+++ b/test/grunt_jamoose_test.coffee
@@ -20,7 +20,7 @@
 
 grunt = require 'grunt'
 
-exports.jamoose =
+exports.grunt_jamoose_test =
   setUp: (done) ->
     # setup here if necessary
     done()

--- a/test/jamoose_test.coffee
+++ b/test/jamoose_test.coffee
@@ -22,25 +22,30 @@ jamoose = require '../src/jamoose'
 
 Mailer = null
 
-exports['jamoose_test'] =
+testTplName = '123'
+testTplData = name: 'asdf'
+
+exports.jamoose_test =
   setUp: (done) ->
     Mailer = new jamoose
       tplPath: __dirname + '/../.tmp/'
+      fromEmail: 'sender@example.org'
+
     done()
 
-  createEmail: (test) ->
-    test.expect(1)
-
-    email = Mailer.createEmail {}
-    test.ok email, 'should get email from provider.'
-
-    test.done()
-
   getHtml: (test) ->
-    test.expect(2)
+    test.expect 2
 
-    Mailer.getHtml '123', { name: 'asdf'}, (err, html) ->
+    Mailer.getHtml testTplName, testTplData, (err, html) ->
       test.ifError err
       test.ok /<h1>asdf<\/h1>/.test(html)
+
+      test.done()
+
+  send: (test) ->
+    test.expect 1
+
+    Mailer.send 'to@example.org', 'Test Sub', testTplName, testTplData, (err) ->
+      test.ifError err
 
       test.done()


### PR DESCRIPTION
- Adding Mandrill as a provider
- eliminating need for `createEmail` (introduces breaking change)
- expand documentation
