### PR TITLE
use step to group multiple asyncs

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -54,7 +54,7 @@ module.exports = (grunt) ->
             expand: true
             flatten: false
             cwd: 'test/fixtures'
-            src: '**\/*.jade'
+            src: '**/*.jade'
             dest: '.tmp'
             ext: '.html'
           }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   ],
   "main": "lib/jamoose",
   "engines": {
-    "node": ">= 0.8.0"
+    "node": ">= 0.10.0"
   },
   "scripts": {
     "test": "grunt test",
@@ -33,12 +33,12 @@
   ],
   "dependencies": {
     "grunt": "~0.4.2",
-    "lodash": "~2.4.1",
+    "hogan.js": "~2.0.0",
     "jade": "~1.0.2",
     "juice": "~0.4.0",
-    "hogan.js": "~2.0.0",
+    "mandrill-api": "~1.0.39",
     "sendgrid": "~1.0.0-rc.1.0",
-    "mandrill-api": "~1.0.39"
+    "step": "0.0.5"
   },
   "devDependencies": {
     "coffee-script": "~1.6.3",

--- a/test/grunt_jamoose_test.coffee
+++ b/test/grunt_jamoose_test.coffee
@@ -26,11 +26,7 @@ exports.grunt_jamoose_test =
     done()
 
   default_options: (test) ->
-    files = ['123', 'testing']
-
-    test.expect files.length
-
-    files.forEach (f) ->
+    ['123', 'testing'].forEach (f) ->
       fname = f + '.html'
       test.equal(
         grunt.file.read('.tmp/' + fname),


### PR DESCRIPTION
after getting a good debug dump of a failed run, it became clear that the simple `jobs` counter wasn't good enough. using a tried and tested way of making sure all of these async functions are completed before marking the task as complete
